### PR TITLE
Thrift changes for handling store failures in replicator

### DIFF
--- a/.generated/go/metadata/ttypes.go
+++ b/.generated/go/metadata/ttypes.go
@@ -3079,11 +3079,13 @@ func (p *ConsumerGroupExtent) String() string {
 //  - ExtentUUID
 //  - Status
 //  - ArchivalLocation
+//  - RemoteExtentPrimaryStore
 type UpdateExtentStatsRequest struct {
-	DestinationUUID  *string              `thrift:"destinationUUID,1" json:"destinationUUID,omitempty"`
-	ExtentUUID       *string              `thrift:"extentUUID,2" json:"extentUUID,omitempty"`
-	Status           *shared.ExtentStatus `thrift:"status,3" json:"status,omitempty"`
-	ArchivalLocation *string              `thrift:"archivalLocation,4" json:"archivalLocation,omitempty"`
+	DestinationUUID          *string              `thrift:"destinationUUID,1" json:"destinationUUID,omitempty"`
+	ExtentUUID               *string              `thrift:"extentUUID,2" json:"extentUUID,omitempty"`
+	Status                   *shared.ExtentStatus `thrift:"status,3" json:"status,omitempty"`
+	ArchivalLocation         *string              `thrift:"archivalLocation,4" json:"archivalLocation,omitempty"`
+	RemoteExtentPrimaryStore *string              `thrift:"remoteExtentPrimaryStore,5" json:"remoteExtentPrimaryStore,omitempty"`
 }
 
 func NewUpdateExtentStatsRequest() *UpdateExtentStatsRequest {
@@ -3125,6 +3127,15 @@ func (p *UpdateExtentStatsRequest) GetArchivalLocation() string {
 	}
 	return *p.ArchivalLocation
 }
+
+var UpdateExtentStatsRequest_RemoteExtentPrimaryStore_DEFAULT string
+
+func (p *UpdateExtentStatsRequest) GetRemoteExtentPrimaryStore() string {
+	if !p.IsSetRemoteExtentPrimaryStore() {
+		return UpdateExtentStatsRequest_RemoteExtentPrimaryStore_DEFAULT
+	}
+	return *p.RemoteExtentPrimaryStore
+}
 func (p *UpdateExtentStatsRequest) IsSetDestinationUUID() bool {
 	return p.DestinationUUID != nil
 }
@@ -3139,6 +3150,10 @@ func (p *UpdateExtentStatsRequest) IsSetStatus() bool {
 
 func (p *UpdateExtentStatsRequest) IsSetArchivalLocation() bool {
 	return p.ArchivalLocation != nil
+}
+
+func (p *UpdateExtentStatsRequest) IsSetRemoteExtentPrimaryStore() bool {
+	return p.RemoteExtentPrimaryStore != nil
 }
 
 func (p *UpdateExtentStatsRequest) Read(iprot thrift.TProtocol) error {
@@ -3169,6 +3184,10 @@ func (p *UpdateExtentStatsRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 4:
 			if err := p.readField4(iprot); err != nil {
+				return err
+			}
+		case 5:
+			if err := p.readField5(iprot); err != nil {
 				return err
 			}
 		default:
@@ -3223,6 +3242,15 @@ func (p *UpdateExtentStatsRequest) readField4(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *UpdateExtentStatsRequest) readField5(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 5: ", err)
+	} else {
+		p.RemoteExtentPrimaryStore = &v
+	}
+	return nil
+}
+
 func (p *UpdateExtentStatsRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("UpdateExtentStatsRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -3237,6 +3265,9 @@ func (p *UpdateExtentStatsRequest) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField4(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField5(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -3303,6 +3334,21 @@ func (p *UpdateExtentStatsRequest) writeField4(oprot thrift.TProtocol) (err erro
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:archivalLocation: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *UpdateExtentStatsRequest) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetRemoteExtentPrimaryStore() {
+		if err := oprot.WriteFieldBegin("remoteExtentPrimaryStore", thrift.STRING, 5); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:remoteExtentPrimaryStore: ", p), err)
+		}
+		if err := oprot.WriteString(string(*p.RemoteExtentPrimaryStore)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.remoteExtentPrimaryStore (5) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:remoteExtentPrimaryStore: ", p), err)
 		}
 	}
 	return err

--- a/.generated/go/shared/ttypes.go
+++ b/.generated/go/shared/ttypes.go
@@ -6753,12 +6753,14 @@ func (p *DeleteConsumerGroupRequest) String() string {
 //  - StoreUUIDs
 //  - InputHostUUID
 //  - OriginZone
+//  - RemoteExtentPrimaryStore
 type Extent struct {
-	ExtentUUID      *string  `thrift:"extentUUID,1" json:"extentUUID,omitempty"`
-	DestinationUUID *string  `thrift:"destinationUUID,2" json:"destinationUUID,omitempty"`
-	StoreUUIDs      []string `thrift:"storeUUIDs,3" json:"storeUUIDs,omitempty"`
-	InputHostUUID   *string  `thrift:"inputHostUUID,4" json:"inputHostUUID,omitempty"`
-	OriginZone      *string  `thrift:"originZone,5" json:"originZone,omitempty"`
+	ExtentUUID               *string  `thrift:"extentUUID,1" json:"extentUUID,omitempty"`
+	DestinationUUID          *string  `thrift:"destinationUUID,2" json:"destinationUUID,omitempty"`
+	StoreUUIDs               []string `thrift:"storeUUIDs,3" json:"storeUUIDs,omitempty"`
+	InputHostUUID            *string  `thrift:"inputHostUUID,4" json:"inputHostUUID,omitempty"`
+	OriginZone               *string  `thrift:"originZone,5" json:"originZone,omitempty"`
+	RemoteExtentPrimaryStore *string  `thrift:"remoteExtentPrimaryStore,6" json:"remoteExtentPrimaryStore,omitempty"`
 }
 
 func NewExtent() *Extent {
@@ -6806,6 +6808,15 @@ func (p *Extent) GetOriginZone() string {
 	}
 	return *p.OriginZone
 }
+
+var Extent_RemoteExtentPrimaryStore_DEFAULT string
+
+func (p *Extent) GetRemoteExtentPrimaryStore() string {
+	if !p.IsSetRemoteExtentPrimaryStore() {
+		return Extent_RemoteExtentPrimaryStore_DEFAULT
+	}
+	return *p.RemoteExtentPrimaryStore
+}
 func (p *Extent) IsSetExtentUUID() bool {
 	return p.ExtentUUID != nil
 }
@@ -6824,6 +6835,10 @@ func (p *Extent) IsSetInputHostUUID() bool {
 
 func (p *Extent) IsSetOriginZone() bool {
 	return p.OriginZone != nil
+}
+
+func (p *Extent) IsSetRemoteExtentPrimaryStore() bool {
+	return p.RemoteExtentPrimaryStore != nil
 }
 
 func (p *Extent) Read(iprot thrift.TProtocol) error {
@@ -6858,6 +6873,10 @@ func (p *Extent) Read(iprot thrift.TProtocol) error {
 			}
 		case 5:
 			if err := p.readField5(iprot); err != nil {
+				return err
+			}
+		case 6:
+			if err := p.readField6(iprot); err != nil {
 				return err
 			}
 		default:
@@ -6933,6 +6952,15 @@ func (p *Extent) readField5(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *Extent) readField6(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 6: ", err)
+	} else {
+		p.RemoteExtentPrimaryStore = &v
+	}
+	return nil
+}
+
 func (p *Extent) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Extent"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -6950,6 +6978,9 @@ func (p *Extent) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField5(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField6(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -7039,6 +7070,21 @@ func (p *Extent) writeField5(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:originZone: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *Extent) writeField6(oprot thrift.TProtocol) (err error) {
+	if p.IsSetRemoteExtentPrimaryStore() {
+		if err := oprot.WriteFieldBegin("remoteExtentPrimaryStore", thrift.STRING, 6); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:remoteExtentPrimaryStore: ", p), err)
+		}
+		if err := oprot.WriteString(string(*p.RemoteExtentPrimaryStore)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.remoteExtentPrimaryStore (6) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:remoteExtentPrimaryStore: ", p), err)
 		}
 	}
 	return err

--- a/idl/cherami_server/metadata.thrift
+++ b/idl/cherami_server/metadata.thrift
@@ -135,6 +135,7 @@ struct UpdateExtentStatsRequest {
   2: optional string extentUUID
   3: optional shared.ExtentStatus status
   4: optional string archivalLocation
+  5: optional string remoteExtentPrimaryStore
 }
 
 struct UpdateExtentStatsResult {

--- a/idl/cherami_server/shared.thrift
+++ b/idl/cherami_server/shared.thrift
@@ -280,6 +280,7 @@ struct Extent {
   3: optional list<string> storeUUIDs
   4: optional string inputHostUUID // Immutable
   5: optional string originZone
+  6: optional string remoteExtentPrimaryStore
 }
 
 enum ExtentStatus {


### PR DESCRIPTION
In order to handle store failures during a replication job,
we need the following changes to the thrift definitions to
identify the remote extent's primary store.
This is Wei Han's (@datoug)'s patch.