### PR TITLE
loadReporter: added status field to node metrics

### DIFF
--- a/.generated/go/controller/tchan-controller.go
+++ b/.generated/go/controller/tchan-controller.go
@@ -87,15 +87,14 @@ func (c *tchanControllerClient) CreateConsumerGroup(ctx thrift.Context, createRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createConsumerGroup")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -109,15 +108,14 @@ func (c *tchanControllerClient) CreateDestination(ctx thrift.Context, createRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createDestination")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -131,15 +129,14 @@ func (c *tchanControllerClient) CreateRemoteZoneExtent(ctx thrift.Context, creat
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createRemoteZoneExtent", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createRemoteZoneExtent")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -153,15 +150,14 @@ func (c *tchanControllerClient) DeleteConsumerGroup(ctx thrift.Context, deleteRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "deleteConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for deleteConsumerGroup")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -175,15 +171,14 @@ func (c *tchanControllerClient) DeleteDestination(ctx thrift.Context, deleteRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "deleteDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for deleteDestination")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -197,10 +192,6 @@ func (c *tchanControllerClient) GetCapacities(ctx thrift.Context, getCapacitiesR
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getCapacities")
-		}
 	}
 
 	return resp.GetSuccess(), err
@@ -213,13 +204,11 @@ func (c *tchanControllerClient) GetInputHosts(ctx thrift.Context, getHostsReques
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getInputHosts", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getInputHosts")
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -233,13 +222,11 @@ func (c *tchanControllerClient) GetOutputHosts(ctx thrift.Context, getHostsReque
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getOutputHosts", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getOutputHosts")
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -253,11 +240,8 @@ func (c *tchanControllerClient) GetQueueDepthInfo(ctx thrift.Context, getQueueDe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getQueueDepthInfo", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.CacheMissError != nil:
-			err = resp.CacheMissError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getQueueDepthInfo")
+		if e := resp.CacheMissError; e != nil {
+			err = e
 		}
 	}
 
@@ -271,10 +255,6 @@ func (c *tchanControllerClient) RemoveCapacities(ctx thrift.Context, removeCapac
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "removeCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for removeCapacities")
-		}
 	}
 
 	return err
@@ -287,10 +267,6 @@ func (c *tchanControllerClient) ReportConsumerGroupExtentMetric(ctx thrift.Conte
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportConsumerGroupExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportConsumerGroupExtentMetric")
-		}
 	}
 
 	return err
@@ -303,10 +279,6 @@ func (c *tchanControllerClient) ReportConsumerGroupMetric(ctx thrift.Context, re
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportConsumerGroupMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportConsumerGroupMetric")
-		}
 	}
 
 	return err
@@ -319,10 +291,6 @@ func (c *tchanControllerClient) ReportDestinationExtentMetric(ctx thrift.Context
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportDestinationExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportDestinationExtentMetric")
-		}
 	}
 
 	return err
@@ -335,10 +303,6 @@ func (c *tchanControllerClient) ReportDestinationMetric(ctx thrift.Context, repo
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportDestinationMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportDestinationMetric")
-		}
 	}
 
 	return err
@@ -351,10 +315,6 @@ func (c *tchanControllerClient) ReportNodeMetric(ctx thrift.Context, reportMetri
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportNodeMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportNodeMetric")
-		}
 	}
 
 	return err
@@ -367,10 +327,6 @@ func (c *tchanControllerClient) ReportStoreExtentMetric(ctx thrift.Context, repo
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportStoreExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportStoreExtentMetric")
-		}
 	}
 
 	return err
@@ -383,15 +339,14 @@ func (c *tchanControllerClient) UpdateConsumerGroup(ctx thrift.Context, updateRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "updateConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for updateConsumerGroup")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -405,15 +360,14 @@ func (c *tchanControllerClient) UpdateDestination(ctx thrift.Context, updateRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "updateDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for updateDestination")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -427,10 +381,6 @@ func (c *tchanControllerClient) UpsertInputHostCapacities(ctx thrift.Context, up
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertInputHostCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertInputHostCapacities")
-		}
 	}
 
 	return err
@@ -443,10 +393,6 @@ func (c *tchanControllerClient) UpsertOutputHostCapacities(ctx thrift.Context, u
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertOutputHostCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertOutputHostCapacities")
-		}
 	}
 
 	return err
@@ -459,10 +405,6 @@ func (c *tchanControllerClient) UpsertStoreCapacities(ctx thrift.Context, upsert
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertStoreCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertStoreCapacities")
-		}
 	}
 
 	return err

--- a/.generated/go/shared/GoUnusedProtection__.go
+++ b/.generated/go/shared/GoUnusedProtection__.go
@@ -23,4 +23,5 @@
 
 package shared
 
-var GoUnusedProtection__ int
+var GoUnusedProtection__ int;
+

--- a/.generated/go/shared/shared-consts.go
+++ b/.generated/go/shared/shared-consts.go
@@ -34,5 +34,7 @@ var _ = thrift.ZERO
 var _ = fmt.Printf
 var _ = bytes.Equal
 
+
 func init() {
 }
+

--- a/idl/cherami_server/controller.thrift
+++ b/idl/cherami_server/controller.thrift
@@ -52,6 +52,12 @@ enum Role {
   STORE
 }
 
+enum NodeStatus {
+  DOWN,
+  UP,
+  GOING_DOWN
+}
+
 struct NodeMetrics {
   1: optional i64 (js.type = "Long") cpu
   2: optional i64 (js.type = "Long") memory
@@ -63,6 +69,7 @@ struct NodeMetrics {
   7: optional i64 (js.type = "Long") outgoingMessagesCounter
   8: optional i64 (js.type = "Long") incomingBytesCounter
   9: optional i64 (js.type = "Long") outgoingBytesCounter
+ 10: optional NodeStatus nodeStatus
 }
 
 struct DestinationMetrics {


### PR DESCRIPTION
This is the first step towards getting the host status reported as part of the regular load reporting.
The node status will be used by the controller for graceful handover of extents during deployments