### PR TITLE
controller: added hoststatus to load reporter.nodeMetrics

### DIFF
--- a/.generated/go/controller/tchan-controller.go
+++ b/.generated/go/controller/tchan-controller.go
@@ -88,15 +88,14 @@ func (c *tchanControllerClient) CreateConsumerGroup(ctx thrift.Context, createRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createConsumerGroup")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -110,15 +109,14 @@ func (c *tchanControllerClient) CreateDestination(ctx thrift.Context, createRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createDestination")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -132,15 +130,14 @@ func (c *tchanControllerClient) CreateRemoteZoneConsumerGroupExtent(ctx thrift.C
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createRemoteZoneConsumerGroupExtent", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createRemoteZoneConsumerGroupExtent")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -154,15 +151,14 @@ func (c *tchanControllerClient) CreateRemoteZoneExtent(ctx thrift.Context, creat
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "createRemoteZoneExtent", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityExistsError != nil:
-			err = resp.EntityExistsError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for createRemoteZoneExtent")
+		if e := resp.EntityExistsError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -176,15 +172,14 @@ func (c *tchanControllerClient) DeleteConsumerGroup(ctx thrift.Context, deleteRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "deleteConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for deleteConsumerGroup")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -198,15 +193,14 @@ func (c *tchanControllerClient) DeleteDestination(ctx thrift.Context, deleteRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "deleteDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for deleteDestination")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -220,10 +214,6 @@ func (c *tchanControllerClient) GetCapacities(ctx thrift.Context, getCapacitiesR
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getCapacities")
-		}
 	}
 
 	return resp.GetSuccess(), err
@@ -236,13 +226,11 @@ func (c *tchanControllerClient) GetInputHosts(ctx thrift.Context, getHostsReques
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getInputHosts", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getInputHosts")
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -256,13 +244,11 @@ func (c *tchanControllerClient) GetOutputHosts(ctx thrift.Context, getHostsReque
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getOutputHosts", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getOutputHosts")
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -276,11 +262,8 @@ func (c *tchanControllerClient) GetQueueDepthInfo(ctx thrift.Context, getQueueDe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "getQueueDepthInfo", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.CacheMissError != nil:
-			err = resp.CacheMissError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for getQueueDepthInfo")
+		if e := resp.CacheMissError; e != nil {
+			err = e
 		}
 	}
 
@@ -294,10 +277,6 @@ func (c *tchanControllerClient) RemoveCapacities(ctx thrift.Context, removeCapac
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "removeCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for removeCapacities")
-		}
 	}
 
 	return err
@@ -310,10 +289,6 @@ func (c *tchanControllerClient) ReportConsumerGroupExtentMetric(ctx thrift.Conte
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportConsumerGroupExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportConsumerGroupExtentMetric")
-		}
 	}
 
 	return err
@@ -326,10 +301,6 @@ func (c *tchanControllerClient) ReportConsumerGroupMetric(ctx thrift.Context, re
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportConsumerGroupMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportConsumerGroupMetric")
-		}
 	}
 
 	return err
@@ -342,10 +313,6 @@ func (c *tchanControllerClient) ReportDestinationExtentMetric(ctx thrift.Context
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportDestinationExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportDestinationExtentMetric")
-		}
 	}
 
 	return err
@@ -358,10 +325,6 @@ func (c *tchanControllerClient) ReportDestinationMetric(ctx thrift.Context, repo
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportDestinationMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportDestinationMetric")
-		}
 	}
 
 	return err
@@ -374,10 +337,6 @@ func (c *tchanControllerClient) ReportNodeMetric(ctx thrift.Context, reportMetri
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportNodeMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportNodeMetric")
-		}
 	}
 
 	return err
@@ -390,10 +349,6 @@ func (c *tchanControllerClient) ReportStoreExtentMetric(ctx thrift.Context, repo
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "reportStoreExtentMetric", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for reportStoreExtentMetric")
-		}
 	}
 
 	return err
@@ -406,15 +361,14 @@ func (c *tchanControllerClient) UpdateConsumerGroup(ctx thrift.Context, updateRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "updateConsumerGroup", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for updateConsumerGroup")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -428,15 +382,14 @@ func (c *tchanControllerClient) UpdateDestination(ctx thrift.Context, updateRequ
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "updateDestination", &args, &resp)
 	if err == nil && !success {
-		switch {
-		case resp.EntityError != nil:
-			err = resp.EntityError
-		case resp.RequestError != nil:
-			err = resp.RequestError
-		case resp.InternalError != nil:
-			err = resp.InternalError
-		default:
-			err = fmt.Errorf("received no result or unknown exception for updateDestination")
+		if e := resp.EntityError; e != nil {
+			err = e
+		}
+		if e := resp.RequestError; e != nil {
+			err = e
+		}
+		if e := resp.InternalError; e != nil {
+			err = e
 		}
 	}
 
@@ -450,10 +403,6 @@ func (c *tchanControllerClient) UpsertInputHostCapacities(ctx thrift.Context, up
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertInputHostCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertInputHostCapacities")
-		}
 	}
 
 	return err
@@ -466,10 +415,6 @@ func (c *tchanControllerClient) UpsertOutputHostCapacities(ctx thrift.Context, u
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertOutputHostCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertOutputHostCapacities")
-		}
 	}
 
 	return err
@@ -482,10 +427,6 @@ func (c *tchanControllerClient) UpsertStoreCapacities(ctx thrift.Context, upsert
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "upsertStoreCapacities", &args, &resp)
 	if err == nil && !success {
-		switch {
-		default:
-			err = fmt.Errorf("received no result or unknown exception for upsertStoreCapacities")
-		}
 	}
 
 	return err

--- a/idl/cherami_server/controller.thrift
+++ b/idl/cherami_server/controller.thrift
@@ -52,6 +52,12 @@ enum Role {
   STORE
 }
 
+enum NodeStatus {
+  DOWN,
+  UP,
+  GOING_DOWN
+}
+
 struct NodeMetrics {
   1: optional i64 (js.type = "Long") cpu
   2: optional i64 (js.type = "Long") memory
@@ -63,6 +69,7 @@ struct NodeMetrics {
   7: optional i64 (js.type = "Long") outgoingMessagesCounter
   8: optional i64 (js.type = "Long") incomingBytesCounter
   9: optional i64 (js.type = "Long") outgoingBytesCounter
+ 10: optional NodeStatus nodeStatus
 }
 
 struct DestinationMetrics {


### PR DESCRIPTION
This is the first step towards getting the host status reported as part of the regular load reporting.
The node status will be used by the controller for graceful handover of extents during deployments
